### PR TITLE
Retrieve exam enrollment on exam retrieve.

### DIFF
--- a/enrollments/tasks.py
+++ b/enrollments/tasks.py
@@ -5,6 +5,17 @@ from enrollments.models import ExamThroughEnrollment
 
 @shared_task
 def calculate_score(exam_through_enrollment_id):
+    """Calculate score for a given exam through enrollment.
+
+    Score the exam submission and update the score in the database.
+    Pass/Fail the submission based on the score.
+
+    Parameters
+    ----------
+    exam_through_enrollment_id : int
+        id of exam through enrollment
+
+    """
     exam_through_enrollment = ExamThroughEnrollment.objects.get(
         id=exam_through_enrollment_id
     )


### PR DESCRIPTION
Apart from submission state, frontend also needed the exam_through_enroll id and so instead of using has submitted the whole exam though enroll is made available to the frontend. If there are no enrollments of the current user into the exam None is returned.