### PR TITLE
Make session dates uneditable after creation.

### DIFF
--- a/enrollments/models.py
+++ b/enrollments/models.py
@@ -155,17 +155,18 @@ class Session(PublishedModel, CreatorBaseModel):
         """Set up tasks on create session."""
         if not self.id:
             super().save(*args, **kwargs)
-        else:
-            # filter the tasks by session id
-            tasks = PeriodicTask.objects.filter(
-                name__in=[self.start_task, self.end_task]
-            )
+            self.setup_tasks()
+        # else:
+        #     # filter the tasks by session id
+        #     tasks = PeriodicTask.objects.filter(
+        #         name__in=[self.start_task, self.end_task]
+        #     )
 
-            # tasks = PeriodicTask.objects.filter(kwargs=json.dumps(
-            # {"session_id": f"{self.id}"}))
-            # delete the tasks
-            tasks.delete()
-        self.setup_tasks()
+        #     # tasks = PeriodicTask.objects.filter(kwargs=json.dumps(
+        #     # {"session_id": f"{self.id}"}))
+        #     # delete the tasks
+        #     tasks.delete()
+        # self.setup_tasks()
         super().save(*args, **kwargs)
 
     def setup_tasks(self):


### PR DESCRIPTION
Making session dates editable after creation bring about several runtime errors that are hard to debug. In order to prevent such errors, user will not be able to update session dates after they have been created.