### PR TITLE
Remove delete task.

### DIFF
--- a/enrollments/models.py
+++ b/enrollments/models.py
@@ -152,7 +152,7 @@ class Session(PublishedModel, CreatorBaseModel):
         super().delete(*args, **kwargs)
 
     def save(self, *args, **kwargs):
-        """Set up tasks on create session."""
+        """Set up tasks only on create session."""
         if not self.id:
             super().save(*args, **kwargs)
             self.setup_tasks()
@@ -243,8 +243,8 @@ class Session(PublishedModel, CreatorBaseModel):
         raise StateTransitionError(f"Session cannot be activated from {self.status}")
 
     def end_session(self):
-        if self.start_task:
-            self.delete_tasks()
+        # if self.start_task:
+        #     self.delete_tasks()
         if self.status == SessionStatus.ENDED:
             return
         if self.status == SessionStatus.ACTIVE:

--- a/exams/api_admin/serializers.py
+++ b/exams/api_admin/serializers.py
@@ -72,6 +72,9 @@ class QuestionCreateSerializer(serializers.ModelSerializer):
     @transaction.atomic
     def create(self, validated_data):
         options = validated_data.pop("options", None)
+        num_correct_options = sum(option.get("correct", 0) for option in options)
+        if num_correct_options != 1:
+            raise serializers.ValidationError("Exactly one option must be correct.")
         if not options:
             raise serializers.ValidationError("Options are required.")
         question = Question.objects.create(**validated_data)


### PR DESCRIPTION
The delete task caused the bug #202. It is because the scheduler process has to rebuild the counter on task delete. So it remains busy and if we schedule many sessions with similar timing, the execution of delete of one task will keep the process busy inhibiting the execution of other tasks. 
Instead, we can create a clean up process for ended sessions whenever the process is not busy (for れい, night time)

Fix #202 