### PR TITLE
Handle error if not enrolled into the exam in trigger.

### DIFF
--- a/exams/api/views.py
+++ b/exams/api/views.py
@@ -115,9 +115,12 @@ def trigger_exam_submit(request, pk):
     # retrieve user
     user = request.user
     # Find the latest exam enrollment of the user
-    exm_enr = ExamThroughEnrollment.objects.filter(
-        enrollment__student=user, exam=exam
-    ).latest("id")
+    try:
+        exm_enr = ExamThroughEnrollment.objects.filter(
+            enrollment__student=user, exam=exam
+        ).latest("id")
+    except ExamThroughEnrollment.DoesNotExist:
+        return Response({"detail": "Exam enrollment not found."}, status=404)
     exm_sess = exm_enr.selected_session
     # Check if the latest exam session is active
     if exm_sess.status != SessionStatus.ACTIVE:


### PR DESCRIPTION
Add try catch in examenrollment.filter.latest. As latest is chained with the filter, it will raise an error if the queryset of examthroughenroll is empty.