### PR TITLE
Load apps befor any other imports.

### DIFF
--- a/apex/asgi.py
+++ b/apex/asgi.py
@@ -5,22 +5,30 @@ It exposes the ASGI callable as a module-level variable named ``application``.
 For more information on this file, see
 https://docs.djangoproject.com/en/4.0/howto/deployment/asgi/
 """
+# flake8: noqa
+# TODO: Fix flake8 errors and add flake8 later on
 
 import os
+
+from django.core.asgi import get_asgi_application
+
+django_asgi_app = get_asgi_application()
 
 from channels.auth import AuthMiddlewareStack
 from channels.routing import ProtocolTypeRouter, URLRouter
 from channels.security.websocket import AllowedHostsOriginValidator
-from django.core.asgi import get_asgi_application
 
 import clock.routing
 
 # from django.core.asgi import get_asgi_application
 
 
+# from django.core.asgi import get_asgi_application
+
+
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "apex.settings")
 
-django_asgi_app = get_asgi_application()
+# django_asgi_app = get_asgi_application()
 
 
 application = ProtocolTypeRouter(


### PR DESCRIPTION
get_asgi_application loads the apps before asgi runs.

Hint: https://github.com/django/channels/issues/1564